### PR TITLE
Changed NullReference Exceptions to Argument and ArgumentNull Exceptions

### DIFF
--- a/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
+++ b/src/Confluent.Kafka/Impl/SafeKafkaHandle.cs
@@ -238,7 +238,7 @@ namespace Confluent.Kafka.Impl
             ThrowIfHandleClosed();
             if (brokers == null)
             {
-                throw new NullReferenceException("List of brokers is required.");
+                throw new ArgumentNullException("brokers", "Argument 'brokers' must not be null.");
             }
             return (int)Librdkafka.brokers_add(handle, brokers);
         }
@@ -652,7 +652,7 @@ namespace Confluent.Kafka.Impl
                     if (partition.Topic == null)
                     {
                         Librdkafka.topic_partition_list_destroy(list);
-                        throw new NullReferenceException("Topic is required to assign partitions.");
+                        throw new ArgumentException("Cannot assign partitions because one or more have a null topic.");
                     }
 
                     IntPtr ptr = Librdkafka.topic_partition_list_add(list, partition.Topic, partition.Partition);
@@ -1021,6 +1021,11 @@ namespace Confluent.Kafka.Impl
         {
             ThrowIfHandleClosed();
 
+            if (group == null)
+            {
+                throw new ArgumentNullException("group", "Argument 'group' must not be null.");
+            }
+
             ErrorCode err = Librdkafka.list_groups(handle, group, out IntPtr grplistPtr, (IntPtr)millisecondsTimeout);
             if (err == ErrorCode.NoError)
             {
@@ -1232,53 +1237,60 @@ namespace Confluent.Kafka.Impl
             setOption_completionSource(optionsPtr, completionSourcePtr);
 
             IntPtr[] newPartitionsPtrs = new IntPtr[newPartitions.Count()];
-            int newPartitionsIdx = 0;
-            foreach (var newPartitionsForTopic in newPartitions)
+            try
             {
-                var topic = newPartitionsForTopic.Topic;
-                var increaseTo = newPartitionsForTopic.IncreaseTo;
-                var assignments = newPartitionsForTopic.ReplicaAssignments;
-
-                if (newPartitionsForTopic.Topic == null)
+                int newPartitionsIdx = 0;
+                foreach (var newPartitionsForTopic in newPartitions)
                 {
-                    throw new NullReferenceException("Cannot assign partition to null topic.");
-                }
+                    var topic = newPartitionsForTopic.Topic;
+                    var increaseTo = newPartitionsForTopic.IncreaseTo;
+                    var assignments = newPartitionsForTopic.ReplicaAssignments;
 
-                IntPtr ptr = Librdkafka.NewPartitions_new(topic, (UIntPtr)increaseTo, errorStringBuilder, (UIntPtr)errorStringBuilder.Capacity);
-                if (ptr == IntPtr.Zero)
-                {
-                    throw new KafkaException(new Error(ErrorCode.Unknown, errorStringBuilder.ToString()));
-                }
-
-                if (assignments != null)
-                {
-                    int assignmentsCount = 0;
-                    foreach (var assignment in assignments)
+                    if (newPartitionsForTopic.Topic == null)
                     {
-                        errorStringBuilder = new StringBuilder(Librdkafka.MaxErrorStringLength);
-                        var brokerIds = assignments[assignmentsCount].ToArray();
-                        var errorCode = Librdkafka.NewPartitions_set_replica_assignment(
-                            ptr,
-                            assignmentsCount,
-                            brokerIds, (UIntPtr)brokerIds.Length,
-                            errorStringBuilder, (UIntPtr)errorStringBuilder.Capacity);
-                        if (errorCode != ErrorCode.NoError)
+                        throw new ArgumentException("Cannot add partitions to a null topic.");
+                    }
+
+                    IntPtr ptr = Librdkafka.NewPartitions_new(topic, (UIntPtr)increaseTo, errorStringBuilder, (UIntPtr)errorStringBuilder.Capacity);
+                    if (ptr == IntPtr.Zero)
+                    {
+                        throw new KafkaException(new Error(ErrorCode.Unknown, errorStringBuilder.ToString()));
+                    }
+
+                    if (assignments != null)
+                    {
+                        int assignmentsCount = 0;
+                        foreach (var assignment in assignments)
                         {
-                            throw new KafkaException(CreatePossiblyFatalError(errorCode, errorStringBuilder.ToString()));
+                            errorStringBuilder = new StringBuilder(Librdkafka.MaxErrorStringLength);
+                            var brokerIds = assignments[assignmentsCount].ToArray();
+                            var errorCode = Librdkafka.NewPartitions_set_replica_assignment(
+                                ptr,
+                                assignmentsCount,
+                                brokerIds, (UIntPtr)brokerIds.Length,
+                                errorStringBuilder, (UIntPtr)errorStringBuilder.Capacity);
+                            if (errorCode != ErrorCode.NoError)
+                            {
+                                throw new KafkaException(CreatePossiblyFatalError(errorCode, errorStringBuilder.ToString()));
+                            }
+                            assignmentsCount += 1;
                         }
-                        assignmentsCount += 1;
+                    }
+                    newPartitionsPtrs[newPartitionsIdx] = ptr;
+                    newPartitionsIdx += 1;
+                }
+
+                Librdkafka.CreatePartitions(handle, newPartitionsPtrs, (UIntPtr)newPartitionsPtrs.Length, optionsPtr, resultQueuePtr);
+            }
+            finally
+            {
+                foreach (var newPartitionPtr in newPartitionsPtrs)
+                {
+                    if (newPartitionPtr != IntPtr.Zero)
+                    {
+                        Librdkafka.NewPartitions_destroy(newPartitionPtr);
                     }
                 }
-
-                newPartitionsPtrs[newPartitionsIdx] = ptr;
-                newPartitionsIdx += 1;
-            }
-
-            Librdkafka.CreatePartitions(handle, newPartitionsPtrs, (UIntPtr)newPartitionsPtrs.Length, optionsPtr, resultQueuePtr);
-
-            foreach (var newPartitionPtr in newPartitionsPtrs)
-            {
-                Librdkafka.NewPartitions_destroy(newPartitionPtr);
             }
 
             Librdkafka.AdminOptions_destroy(optionsPtr);
@@ -1298,25 +1310,33 @@ namespace Confluent.Kafka.Impl
             setOption_OperationTimeout(optionsPtr, options.OperationTimeout);
             setOption_completionSource(optionsPtr, completionSourcePtr);
 
-            IntPtr[] deleteTopicsPtrs = new IntPtr[deleteTopics.Count(t => t != null)];
-            int idx = 0;
-            foreach (var deleteTopic in deleteTopics)
+            IntPtr[] deleteTopicsPtrs = new IntPtr[deleteTopics.Count()];
+            try
             {
-                if (deleteTopic == null)
+                int idx = 0;
+                foreach (var deleteTopic in deleteTopics)
                 {
-                    continue;
+                    if (deleteTopic == null)
+                    {
+                        throw new ArgumentException("Cannot delete topics because one or more topics were specified as null.");
+                    }
+
+                    var deleteTopicPtr = Librdkafka.DeleteTopic_new(deleteTopic);
+                    deleteTopicsPtrs[idx] = deleteTopicPtr;
+                    idx += 1;
                 }
 
-                var deleteTopicPtr = Librdkafka.DeleteTopic_new(deleteTopic);
-                deleteTopicsPtrs[idx] = deleteTopicPtr;
-                idx += 1;
+                Librdkafka.DeleteTopics(handle, deleteTopicsPtrs, (UIntPtr)deleteTopicsPtrs.Length, optionsPtr, resultQueuePtr);
             }
-
-            Librdkafka.DeleteTopics(handle, deleteTopicsPtrs, (UIntPtr)deleteTopicsPtrs.Length, optionsPtr, resultQueuePtr);
-
-            foreach (var deleteTopicPtr in deleteTopicsPtrs)
+            finally
             {
-                Librdkafka.DeleteTopic_destroy(deleteTopicPtr);
+                foreach (var deleteTopicPtr in deleteTopicsPtrs)
+                {
+                    if (deleteTopicPtr != IntPtr.Zero)
+                    {
+                        Librdkafka.DeleteTopic_destroy(deleteTopicPtr);
+                    }
+                }
             }
 
             Librdkafka.AdminOptions_destroy(optionsPtr);
@@ -1340,59 +1360,72 @@ namespace Confluent.Kafka.Impl
             setOption_completionSource(optionsPtr, completionSourcePtr);
 
             IntPtr[] newTopicPtrs = new IntPtr[newTopics.Count()];
-            int idx = 0;
-            foreach (var newTopic in newTopics)
+            try
             {
-                if (newTopic.ReplicationFactor != -1 && newTopic.ReplicasAssignments != null)
+                int idx = 0;
+                foreach (var newTopic in newTopics)
                 {
-                    throw new ArgumentException("ReplicationFactor must be -1 when ReplicasAssignments are specified.");
-                }
-
-                IntPtr newTopicPtr = Librdkafka.NewTopic_new(
-                    newTopic.Name, 
-                    (IntPtr)newTopic.NumPartitions, 
-                    (IntPtr)newTopic.ReplicationFactor,
-                    errorStringBuilder, 
-                    (UIntPtr)errorStringBuilder.Capacity);
-                if (newTopicPtr == IntPtr.Zero)
-                {
-                    throw new KafkaException(new Error(ErrorCode.Unknown, errorStringBuilder.ToString()));
-                }
-
-                if (newTopic.ReplicasAssignments != null)
-                {
-                    foreach (var replicAssignment in newTopic.ReplicasAssignments)
+                    if (newTopic.ReplicationFactor != -1 && newTopic.ReplicasAssignments != null)
                     {
-                        var partition = replicAssignment.Key;
-                        var brokerIds = replicAssignment.Value.ToArray();
-                        var errorCode = Librdkafka.NewTopic_set_replica_assignment(
-                                            newTopicPtr,
-                                            partition, brokerIds, (UIntPtr)brokerIds.Length, 
-                                            errorStringBuilder, (UIntPtr)errorStringBuilder.Capacity);
-                        if (errorCode != ErrorCode.NoError)
+                        throw new ArgumentException("ReplicationFactor must be -1 when ReplicasAssignments are specified.");
+                    }
+
+                    if (newTopic.Name == null)
+                    {
+                        throw new ArgumentException($"Cannot create a topic with a name of null.", "name");
+                    }
+
+                    IntPtr newTopicPtr = Librdkafka.NewTopic_new(
+                        newTopic.Name,
+                        (IntPtr)newTopic.NumPartitions,
+                        (IntPtr)newTopic.ReplicationFactor,
+                        errorStringBuilder,
+                        (UIntPtr)errorStringBuilder.Capacity);
+                    if (newTopicPtr == IntPtr.Zero)
+                    {
+                        throw new KafkaException(new Error(ErrorCode.Unknown, errorStringBuilder.ToString()));
+                    }
+
+                    if (newTopic.ReplicasAssignments != null)
+                    {
+                        foreach (var replicAssignment in newTopic.ReplicasAssignments)
                         {
-                            throw new KafkaException(CreatePossiblyFatalError(errorCode, errorStringBuilder.ToString()));
+                            var partition = replicAssignment.Key;
+                            var brokerIds = replicAssignment.Value.ToArray();
+                            var errorCode = Librdkafka.NewTopic_set_replica_assignment(
+                                                newTopicPtr,
+                                                partition, brokerIds, (UIntPtr)brokerIds.Length,
+                                                errorStringBuilder, (UIntPtr)errorStringBuilder.Capacity);
+                            if (errorCode != ErrorCode.NoError)
+                            {
+                                throw new KafkaException(CreatePossiblyFatalError(errorCode, errorStringBuilder.ToString()));
+                            }
                         }
                     }
+
+                    if (newTopic.Configs != null)
+                    {
+                        foreach (var config in newTopic.Configs)
+                        {
+                            Librdkafka.NewTopic_set_config(newTopicPtr, config.Key, config.Value);
+                        }
+                    }
+
+                    newTopicPtrs[idx] = newTopicPtr;
+                    idx += 1;
                 }
 
-                if (newTopic.Configs != null)
-                {   
-                    foreach (var config in newTopic.Configs)
+                Librdkafka.CreateTopics(handle, newTopicPtrs, (UIntPtr)newTopicPtrs.Length, optionsPtr, resultQueuePtr);
+            }
+            finally
+            {
+                foreach (var newTopicPtr in newTopicPtrs)
+                {
+                    if (newTopicPtr != IntPtr.Zero)
                     {
-                        Librdkafka.NewTopic_set_config(newTopicPtr, config.Key, config.Value);
+                        Librdkafka.NewTopic_destroy(newTopicPtr);
                     }
                 }
-
-                newTopicPtrs[idx] = newTopicPtr;
-                idx += 1;
-            }
-
-            Librdkafka.CreateTopics(handle, newTopicPtrs, (UIntPtr)newTopicPtrs.Length, optionsPtr, resultQueuePtr);
-
-            foreach (var newTopicPtr in newTopicPtrs)
-            {
-                Librdkafka.NewTopic_destroy(newTopicPtr);
             }
 
             Librdkafka.AdminOptions_destroy(optionsPtr);

--- a/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
+++ b/test/Confluent.Kafka.IntegrationTests/Tests/AdminClient_NullReferenceChecks.cs
@@ -38,6 +38,8 @@ namespace Confluent.Kafka.IntegrationTests
             var topicName1 = Guid.NewGuid().ToString();
             string nullTopic = null;
 
+            Exception createTopicsException = null;
+            Exception createPartitionsException = null;
             // test creating a null topic throws a related exception
             using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
@@ -47,9 +49,10 @@ namespace Confluent.Kafka.IntegrationTests
                     adminClient.CreateTopicsAsync(new TopicSpecification[] { new TopicSpecification { Name = nullTopic, NumPartitions = 1, ReplicationFactor = 1 } }).Wait();
                     Assert.True(false, "Expected exception.");
                 }
-                catch (KafkaException ex)
+                catch (ArgumentException ex)
                 {
                     Assert.Contains("topic", ex.Message.ToLower());
+                    createTopicsException = ex;
                 }
             }
 
@@ -63,11 +66,15 @@ namespace Confluent.Kafka.IntegrationTests
                     adminClient.CreatePartitionsAsync(new List<PartitionsSpecification> { new PartitionsSpecification { Topic = nullTopic, IncreaseTo = 2 } }).Wait();
                     Assert.True(false, "Expected exception.");
                 }
-                catch (NullReferenceException ex)
+                catch (ArgumentException ex)
                 {
                     Assert.Contains("topic", ex.Message.ToLower());
+                    createPartitionsException = ex;
                 }
             }
+
+            Assert.True(createTopicsException != null && createPartitionsException != null);
+            Assert.True(createTopicsException.GetType() == createPartitionsException.GetType(), ".CreateTopic and .CreatePartition should have consistent interface for null-related exceptions.");
 
             // test adding a null list of brokers throws null reference exception.
             using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
@@ -78,7 +85,7 @@ namespace Confluent.Kafka.IntegrationTests
                     adminClient.AddBrokers(null);
                     Assert.True(false, "Expected exception.");
                 }
-                catch (NullReferenceException ex)
+                catch (ArgumentNullException ex)
                 {
                     Assert.Contains("broker", ex.Message.ToLower());
                 }
@@ -99,21 +106,33 @@ namespace Confluent.Kafka.IntegrationTests
                 }
             }
 
-            // This test-case completing is the test case
-            // Used to cause a seg-fault.
+            // Deleting null topic throws exception
             using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient.DeleteTopicsAsync(new List<string> { topicName1, nullTopic });
-                Assert.True(true);
+                try
+                {
+                    adminClient.DeleteTopicsAsync(new List<string> { topicName1, nullTopic });
+                    Assert.True(false, "Expected exception.");
+                }
+                catch (ArgumentException ex)
+                {
+                    Assert.Contains("topic", ex.Message);
+                }
             }
 
-            // Asserts existing ListGroup behavior - null group is valid option
+            // ListGroup throws exception if group is null
             using (var producer = new ProducerBuilder<Null, Null>(new ProducerConfig { BootstrapServers = bootstrapServers }).Build())
             using (var adminClient = new DependentAdminClientBuilder(producer.Handle).Build())
             {
-                adminClient.ListGroup(null, TimeSpan.FromSeconds(10));
-                Assert.True(true);
+                try
+                {
+                    adminClient.ListGroup(null, TimeSpan.FromSeconds(10));
+                }
+                catch (ArgumentNullException ex)
+                {
+                    Assert.Contains("group", ex.Message);
+                }
             }
 
             Assert.Equal(0, Library.HandleCount);


### PR DESCRIPTION
Changed exception types for null arguments to Argument and ArgumentNull exceptions. Aligned null argument exception types for CreatePartition and CreateTopic calls. Added disposal logic for various methods that threw argument exceptions. Modified the AdminClient.ListGroup to throw an exception when the provided group is null.